### PR TITLE
GRIDEDIT-1869: pull remote release branch

### DIFF
--- a/scripts/automation/github.sh
+++ b/scripts/automation/github.sh
@@ -110,9 +110,12 @@ function create_release_branch() {
     local remote_ref=$(
         git -C ${repo_path} ls-remote --heads origin "${release_branch}"
     )
+
+    # Pull the remote branch if exists
     if [[ -n "${remote_ref}" ]]; then
-        echo "Remote branch exists ${release_branch} exists."
+        echo "Remote branch ${release_branch} exists."
         echo "Found "${remote_ref}""
+	git -C ${repo_path} pull origin ${release_branch}
     else
         # push it to remote
         # not sure if force pushing is necessary because of the if statement


### PR DESCRIPTION
When making a patch release with cherry-picked changes, the release branch already exists, and the starting point is the same as the version number. In that scenario the remote branch needs to be pulled.

Note that this change only does the pull, but still first creates the changes on the local branch. An improvement would be to first detect the existence of the release branch and pull it, and not make any local changes.